### PR TITLE
Enable the remote connection to mongoDB atlas

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -36,7 +36,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
 
-mongoose.connect("mongodb://localhost:27017/movieDB");
+mongoose.connect("mongodb+srv://jeanba19:"+process.env.CLUSTER+"@clustermoviewebapp.2rflxi7.mongodb.net/movieDB");
 
 
 const apiKey = process.env.APIKEY;


### PR DESCRIPTION
Replace the MongoDB local connection string with the connection string of the MongoDB atlas. As we will now host our database on the cloud we needed to change the connection string to was here temporarily